### PR TITLE
Allow CloudWatch namespace to be specifiable via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,25 @@ Config.log_stream_name = "LogStreamName";
 AWS_EMF_LOG_STREAM_NAME = LogStreamName;
 ```
 
+**NameSpace**: Overrides the CloudWatch [namespace](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Namespace). If not set, a default value of aws-embedded-metrics will be used.
+
+Requirements:
+
+- Name Length 1-512 characters
+- Name must be ASCII characters only
+
+Example:
+
+```py
+# in process
+from aws_embedded_metrics.config import get_config
+Config = get_config()
+Config.namespace = "MyApplication";
+
+# environment
+AWS_EMF_NAMESPACE = MyApplication;
+```
+
 ## Examples
 
 Check out the [examples](https://github.com/awslabs/aws-embedded-metrics-python/tree/master/examples) directory to get started.

--- a/aws_embedded_metrics/config/configuration.py
+++ b/aws_embedded_metrics/config/configuration.py
@@ -22,6 +22,7 @@ class Configuration:
         log_stream_name: str,
         agent_endpoint: str,
         ec2_metadata_endpoint: str = None,
+        namespace: str = None,
     ):
         self.debug_logging_enabled = debug_logging_enabled
         self.service_name = service_name
@@ -30,3 +31,4 @@ class Configuration:
         self.log_stream_name = log_stream_name
         self.agent_endpoint = agent_endpoint
         self.ec2_metadata_endpoint = ec2_metadata_endpoint
+        self.namespace = namespace

--- a/aws_embedded_metrics/config/environment_configuration_provider.py
+++ b/aws_embedded_metrics/config/environment_configuration_provider.py
@@ -23,6 +23,7 @@ LOG_GROUP_NAME = "LOG_GROUP_NAME"
 LOG_STREAM_NAME = "LOG_STREAM_NAME"
 AGENT_ENDPOINT = "AGENT_ENDPOINT"
 EC2_METADATA_ENDPOINT = "EC2_METADATA_ENDPOINT"
+NAMESPACE = "NAMESPACE"
 
 
 class EnvironmentConfigurationProvider:
@@ -39,6 +40,7 @@ class EnvironmentConfigurationProvider:
             self.__get_env_var(LOG_STREAM_NAME),
             self.__get_env_var(AGENT_ENDPOINT),
             self.__get_env_var(EC2_METADATA_ENDPOINT),
+            self.__get_env_var(NAMESPACE),
         )
 
     @staticmethod

--- a/aws_embedded_metrics/logger/metrics_context.py
+++ b/aws_embedded_metrics/logger/metrics_context.py
@@ -13,6 +13,7 @@
 
 
 from aws_embedded_metrics import constants, utils
+from aws_embedded_metrics.config import get_config
 from aws_embedded_metrics.logger.metric import Metric
 from typing import List, Dict, Any
 
@@ -30,7 +31,7 @@ class MetricsContext(object):
         default_dimensions: Dict[str, str] = None,
     ):
 
-        self.namespace: str = namespace or constants.DEFAULT_NAMESPACE
+        self.namespace: str = namespace or get_config().namespace or constants.DEFAULT_NAMESPACE
         self.properties: Dict[str, Any] = properties or {}
         self.dimensions: List[Dict[str, str]] = dimensions or []
         self.default_dimensions: Dict[str, str] = default_dimensions or {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws-embedded-metrics",
-    version="1.0.1b3",
+    version="1.0.1b4",
     author="Amazon Web Services",
     author_email="jarnance@amazon.com",
     description="AWS Embedded Metrics Package",

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,6 +1,5 @@
 from aws_embedded_metrics import config
 from faker import Faker
-import os
 from importlib import reload
 
 
@@ -14,7 +13,7 @@ def get_config():
     return config.get_config()
 
 
-def test_can_get_config_from_environment():
+def test_can_get_config_from_environment(monkeypatch):
     # arrange
     debug_enabled = True
     service_name = fake.word()
@@ -24,13 +23,13 @@ def test_can_get_config_from_environment():
     agent_endpoint = fake.word()
     ec2_metadata_endpoint = fake.word()
 
-    os.environ["AWS_EMF_ENABLE_DEBUG_LOGGING"] = str(debug_enabled)
-    os.environ["AWS_EMF_SERVICE_NAME"] = service_name
-    os.environ["AWS_EMF_SERVICE_TYPE"] = service_type
-    os.environ["AWS_EMF_LOG_GROUP_NAME"] = log_group
-    os.environ["AWS_EMF_LOG_STREAM_NAME"] = log_stream
-    os.environ["AWS_EMF_AGENT_ENDPOINT"] = agent_endpoint
-    os.environ["AWS_EMF_EC2_METADATA_ENDPOINT"] = ec2_metadata_endpoint
+    monkeypatch.setenv("AWS_EMF_ENABLE_DEBUG_LOGGING", str(debug_enabled))
+    monkeypatch.setenv("AWS_EMF_SERVICE_NAME", service_name)
+    monkeypatch.setenv("AWS_EMF_SERVICE_TYPE", service_type)
+    monkeypatch.setenv("AWS_EMF_LOG_GROUP_NAME", log_group)
+    monkeypatch.setenv("AWS_EMF_LOG_STREAM_NAME", log_stream)
+    monkeypatch.setenv("AWS_EMF_AGENT_ENDPOINT", agent_endpoint)
+    monkeypatch.setenv("AWS_EMF_EC2_METADATA_ENDPOINT", ec2_metadata_endpoint)
 
     # act
     result = get_config()
@@ -45,15 +44,15 @@ def test_can_get_config_from_environment():
     assert result.ec2_metadata_endpoint == ec2_metadata_endpoint
 
 
-def test_can_override_config():
+def test_can_override_config(monkeypatch):
     # arrange
-    os.environ["AWS_EMF_ENABLE_DEBUG_LOGGING"] = str(True)
-    os.environ["AWS_EMF_SERVICE_NAME"] = fake.word()
-    os.environ["AWS_EMF_SERVICE_TYPE"] = fake.word()
-    os.environ["AWS_EMF_LOG_GROUP_NAME"] = fake.word()
-    os.environ["AWS_EMF_LOG_STREAM_NAME"] = fake.word()
-    os.environ["AWS_EMF_AGENT_ENDPOINT"] = fake.word()
-    os.environ["AWS_EMF_EC2_METADATA_ENDPOINT"] = fake.word()
+    monkeypatch.setenv("AWS_EMF_ENABLE_DEBUG_LOGGING", str(True))
+    monkeypatch.setenv("AWS_EMF_SERVICE_NAME", fake.word())
+    monkeypatch.setenv("AWS_EMF_SERVICE_TYPE", fake.word())
+    monkeypatch.setenv("AWS_EMF_LOG_GROUP_NAME", fake.word())
+    monkeypatch.setenv("AWS_EMF_LOG_STREAM_NAME", fake.word())
+    monkeypatch.setenv("AWS_EMF_AGENT_ENDPOINT", fake.word())
+    monkeypatch.setenv("AWS_EMF_EC2_METADATA_ENDPOINT", fake.word())
 
     config = get_config()
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -22,6 +22,7 @@ def test_can_get_config_from_environment(monkeypatch):
     log_stream = fake.word()
     agent_endpoint = fake.word()
     ec2_metadata_endpoint = fake.word()
+    namespace = fake.word()
 
     monkeypatch.setenv("AWS_EMF_ENABLE_DEBUG_LOGGING", str(debug_enabled))
     monkeypatch.setenv("AWS_EMF_SERVICE_NAME", service_name)
@@ -30,6 +31,7 @@ def test_can_get_config_from_environment(monkeypatch):
     monkeypatch.setenv("AWS_EMF_LOG_STREAM_NAME", log_stream)
     monkeypatch.setenv("AWS_EMF_AGENT_ENDPOINT", agent_endpoint)
     monkeypatch.setenv("AWS_EMF_EC2_METADATA_ENDPOINT", ec2_metadata_endpoint)
+    monkeypatch.setenv("AWS_EMF_NAMESPACE", namespace)
 
     # act
     result = get_config()
@@ -42,6 +44,7 @@ def test_can_get_config_from_environment(monkeypatch):
     assert result.log_stream_name == log_stream
     assert result.agent_endpoint == agent_endpoint
     assert result.ec2_metadata_endpoint == ec2_metadata_endpoint
+    assert result.namespace == namespace
 
 
 def test_can_override_config(monkeypatch):
@@ -53,6 +56,7 @@ def test_can_override_config(monkeypatch):
     monkeypatch.setenv("AWS_EMF_LOG_STREAM_NAME", fake.word())
     monkeypatch.setenv("AWS_EMF_AGENT_ENDPOINT", fake.word())
     monkeypatch.setenv("AWS_EMF_EC2_METADATA_ENDPOINT", fake.word())
+    monkeypatch.setenv("AWS_EMF_NAMESPACE", fake.word())
 
     config = get_config()
 
@@ -63,6 +67,7 @@ def test_can_override_config(monkeypatch):
     log_stream = fake.word()
     agent_endpoint = fake.word()
     ec2_metadata_endpoint = fake.word()
+    namespace = fake.word()
 
     # act
     config.debug_logging_enabled = debug_enabled
@@ -72,6 +77,7 @@ def test_can_override_config(monkeypatch):
     config.log_stream_name = log_stream
     config.agent_endpoint = agent_endpoint
     config.ec2_metadata_endpoint = ec2_metadata_endpoint
+    config.namespace = namespace
 
     # assert
     assert config.debug_logging_enabled == debug_enabled
@@ -81,3 +87,4 @@ def test_can_override_config(monkeypatch):
     assert config.log_stream_name == log_stream
     assert config.agent_endpoint == agent_endpoint
     assert config.ec2_metadata_endpoint == ec2_metadata_endpoint
+    assert config.namespace == namespace

--- a/tests/logger/test_metrics_context.py
+++ b/tests/logger/test_metrics_context.py
@@ -1,7 +1,10 @@
+from aws_embedded_metrics import config
 from aws_embedded_metrics.logger.metrics_context import MetricsContext
 from aws_embedded_metrics import utils
+from aws_embedded_metrics.constants import DEFAULT_NAMESPACE
 from _pytest.monkeypatch import MonkeyPatch
 import pytest
+from importlib import reload
 from faker import Faker
 
 fake = Faker()
@@ -16,12 +19,16 @@ def mock_time():
 
 
 def test_can_create_context_with_no_arguments(mock_time):
+    # reload the configuration module since it is loaded on
+    # startup and cached
+    reload(config)
+
     # arrange
     # act
     context = MetricsContext()
 
     # assert
-    assert context.namespace == "aws-embedded-metrics"
+    assert context.namespace == DEFAULT_NAMESPACE
     assert context.meta == {"Timestamp": mock_time}
     assert context.properties == {}
     assert context.dimensions == []


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-embedded-metrics-python/issues/15

*Description of changes:*

Allow CloudWatch namespace to be specifiable via environment variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
