### PR TITLE
Added MetricsLogger.add_stack_trace()

### DIFF
--- a/aws_embedded_metrics/__init__.py
+++ b/aws_embedded_metrics/__init__.py
@@ -13,4 +13,6 @@
 
 name = "aws_embedded_metrics"
 
-from aws_embedded_metrics.metric_scope import metric_scope  # noqa: F401
+from aws_embedded_metrics.metric_scope import metric_scope  # noqa: F401 E402
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger  # noqa: F401 E402
+from aws_embedded_metrics.logger.metrics_context import MetricsContext  # noqa: F401 E402


### PR DESCRIPTION
Implements #38 

Description of changes: Added the `MetricsLogger.add_stack_trace()` method, which takes a key, an optional value, and an optional `exc_info` tuple (if not given, it uses `sys.exc_info()`). It adds a property using that key, with the following value:
```json5
{
  "property_key": {
    "value": "optional_value", // only if present
    "error_type": "module.SomeError", // module omitted for builtins
    "error_str": "result of str(e)",
    "stack_trace": [
      // traceback.format_tb()
    ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
