### PR TITLE
Add MetricsContext and MetricsLogger to top-level imports

### DIFF
--- a/aws_embedded_metrics/__init__.py
+++ b/aws_embedded_metrics/__init__.py
@@ -13,4 +13,6 @@
 
 name = "aws_embedded_metrics"
 
-from aws_embedded_metrics.metric_scope import metric_scope  # noqa: F401
+from aws_embedded_metrics.metric_scope import metric_scope  # noqa: F401 E402
+from aws_embedded_metrics.logger.metrics_logger import MetricsLogger  # noqa: F401 E402
+from aws_embedded_metrics.logger.metrics_context import MetricsContext  # noqa: F401 E402


### PR DESCRIPTION
Closes #37 

Adding type hints means having the `MetricsLogger` and `MetricsContext` classes easier to access is useful.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
