### PR TITLE
Add a DISABLE_METRIC_EXTRACTION config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,21 @@ Config.namespace = "MyApplication"
 AWS_EMF_NAMESPACE = MyApplication
 ```
 
+**DISABLE_METRIC_EXTRACTION**: Disables extraction of metrics by CloudWatch, by omitting EMF
+metadata from serialized log records.
+
+Example:
+
+```py
+# in process
+from aws_embedded_metrics.config import get_config
+Config = get_config()
+Config.disable_metric_extraction = True
+
+# environment
+AWS_EMF_DISABLE_METRIC_EXTRACTION = true
+```
+
 ## Examples
 
 Check out the [examples](https://github.com/awslabs/aws-embedded-metrics-python/tree/master/examples) directory to get started.

--- a/aws_embedded_metrics/config/configuration.py
+++ b/aws_embedded_metrics/config/configuration.py
@@ -23,6 +23,7 @@ class Configuration:
         agent_endpoint: str,
         ec2_metadata_endpoint: str = None,
         namespace: str = None,
+        disable_metric_extraction: bool = False,
     ):
         self.debug_logging_enabled = debug_logging_enabled
         self.service_name = service_name
@@ -32,3 +33,4 @@ class Configuration:
         self.agent_endpoint = agent_endpoint
         self.ec2_metadata_endpoint = ec2_metadata_endpoint
         self.namespace = namespace
+        self.disable_metric_extraction = disable_metric_extraction

--- a/aws_embedded_metrics/config/environment_configuration_provider.py
+++ b/aws_embedded_metrics/config/environment_configuration_provider.py
@@ -24,6 +24,7 @@ LOG_STREAM_NAME = "LOG_STREAM_NAME"
 AGENT_ENDPOINT = "AGENT_ENDPOINT"
 EC2_METADATA_ENDPOINT = "EC2_METADATA_ENDPOINT"
 NAMESPACE = "NAMESPACE"
+DISABLE_METRIC_EXTRACTION = "DISABLE_METRIC_EXTRACTION"
 
 
 class EnvironmentConfigurationProvider:
@@ -41,6 +42,7 @@ class EnvironmentConfigurationProvider:
             self.__get_env_var(AGENT_ENDPOINT),
             self.__get_env_var(EC2_METADATA_ENDPOINT),
             self.__get_env_var(NAMESPACE),
+            self.__get_bool_env_var(DISABLE_METRIC_EXTRACTION),
         )
 
     @staticmethod

--- a/aws_embedded_metrics/serializers/log_serializer.py
+++ b/aws_embedded_metrics/serializers/log_serializer.py
@@ -19,7 +19,6 @@ import json
 from typing import Any, Dict, List
 
 
-
 class LogSerializer(Serializer):
     @staticmethod
     def serialize(context: MetricsContext) -> List[str]:
@@ -34,7 +33,7 @@ class LogSerializer(Serializer):
             dimensions_properties = {**dimensions_properties, **dimension_set}
 
         def create_body() -> Dict[str, Any]:
-            body = {
+            body: Dict[str, Any] = {
                 **dimensions_properties,
                 **context.properties,
             }

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -23,6 +23,7 @@ def test_can_get_config_from_environment(monkeypatch):
     agent_endpoint = fake.word()
     ec2_metadata_endpoint = fake.word()
     namespace = fake.word()
+    disable_metric_extraction = True
 
     monkeypatch.setenv("AWS_EMF_ENABLE_DEBUG_LOGGING", str(debug_enabled))
     monkeypatch.setenv("AWS_EMF_SERVICE_NAME", service_name)
@@ -32,6 +33,7 @@ def test_can_get_config_from_environment(monkeypatch):
     monkeypatch.setenv("AWS_EMF_AGENT_ENDPOINT", agent_endpoint)
     monkeypatch.setenv("AWS_EMF_EC2_METADATA_ENDPOINT", ec2_metadata_endpoint)
     monkeypatch.setenv("AWS_EMF_NAMESPACE", namespace)
+    monkeypatch.setenv("AWS_EMF_DISABLE_METRIC_EXTRACTION", str(disable_metric_extraction))
 
     # act
     result = get_config()
@@ -45,6 +47,7 @@ def test_can_get_config_from_environment(monkeypatch):
     assert result.agent_endpoint == agent_endpoint
     assert result.ec2_metadata_endpoint == ec2_metadata_endpoint
     assert result.namespace == namespace
+    assert result.disable_metric_extraction == disable_metric_extraction
 
 
 def test_can_override_config(monkeypatch):
@@ -57,6 +60,7 @@ def test_can_override_config(monkeypatch):
     monkeypatch.setenv("AWS_EMF_AGENT_ENDPOINT", fake.word())
     monkeypatch.setenv("AWS_EMF_EC2_METADATA_ENDPOINT", fake.word())
     monkeypatch.setenv("AWS_EMF_NAMESPACE", fake.word())
+    monkeypatch.setenv("AWS_EMF_DISABLE_METRIC_EXTRACTION", str(True))
 
     config = get_config()
 
@@ -68,6 +72,7 @@ def test_can_override_config(monkeypatch):
     agent_endpoint = fake.word()
     ec2_metadata_endpoint = fake.word()
     namespace = fake.word()
+    disable_metric_extraction = False
 
     # act
     config.debug_logging_enabled = debug_enabled
@@ -78,6 +83,7 @@ def test_can_override_config(monkeypatch):
     config.agent_endpoint = agent_endpoint
     config.ec2_metadata_endpoint = ec2_metadata_endpoint
     config.namespace = namespace
+    config.disable_metric_extraction = disable_metric_extraction
 
     # assert
     assert config.debug_logging_enabled == debug_enabled
@@ -88,3 +94,4 @@ def test_can_override_config(monkeypatch):
     assert config.agent_endpoint == agent_endpoint
     assert config.ec2_metadata_endpoint == ec2_metadata_endpoint
     assert config.namespace == namespace
+    assert config.disable_metric_extraction == disable_metric_extraction

--- a/tests/serializer/test_log_serializer.py
+++ b/tests/serializer/test_log_serializer.py
@@ -1,3 +1,4 @@
+from aws_embedded_metrics.config import get_config
 from aws_embedded_metrics.logger.metrics_context import MetricsContext
 from aws_embedded_metrics.serializers.log_serializer import LogSerializer
 from faker import Faker
@@ -175,6 +176,27 @@ def test_serialize_metrics_with_multiple_datapoints():
     # assert
     assert len(results) == 1
     assert results == [json.dumps(expected)]
+
+
+def test_serialize_metrics_with_aggregation_disabled():
+    """Test log records don't contain metadata when aggregation is disabled."""
+    # arrange
+    config = get_config()
+    config.disable_metric_extraction = True
+
+    expected_key = fake.word()
+    expected_value = fake.random.randrange(0, 100)
+
+    expected = {expected_key: expected_value}
+
+    context = get_context()
+    context.put_metric(expected_key, expected_value)
+
+    # act
+    result_json = serializer.serialize(context)[0]
+
+    # assert
+    assert_json_equality(result_json, expected)
 
 
 # Test utility method

--- a/tests/sinks/test_lambda_sink.py
+++ b/tests/sinks/test_lambda_sink.py
@@ -1,3 +1,6 @@
+from importlib import reload
+
+from aws_embedded_metrics import config
 from aws_embedded_metrics.sinks.lambda_sink import LambdaSink
 from aws_embedded_metrics.logger.metrics_context import MetricsContext
 from faker import Faker
@@ -9,6 +12,8 @@ fake = Faker()
 
 def test_accept_writes_to_stdout(capfd):
     # arrange
+    reload(config)
+
     sink = LambdaSink()
     context = MetricsContext.empty()
     context.meta["Timestamp"] = 1


### PR DESCRIPTION
This adds a new configuration option `DISABLE_METRIC_EXTRACTION` which
removes the `_aws` metadata from the EMF log records, thus disabling the
extraction of metrics by CloudWatch Metrics. The remaining part of the
log records is still getting logged.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.

Fixes #34 