### PR TITLE
Pin agent version

### DIFF
--- a/tests/integ/agent/Dockerfile
+++ b/tests/integ/agent/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update &&  \
     apt-get install -y ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -O https://amazon-cloud-watch-agent.s3.amazonaws.com/debian/amd64/latest/amazon-cloudwatch-agent.deb && \
+RUN curl -O https://amazon-cloud-watch-agent.s3.amazonaws.com/debian/amd64/1.237768.0/amazon-cloudwatch-agent.deb && \
     dpkg -i -E amazon-cloudwatch-agent.deb && \
     rm -rf /tmp/* && \
     rm -rf /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-config-wizard && \


### PR DESCRIPTION
Testing an issue with the latest CW Agent. Build hangs because the output of the agent changed:

https://github.com/awslabs/aws-embedded-metrics-python/blob/master/bin/run-integ-tests.sh#L28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
