### PR TITLE
Add LocalEnvironment using stdout

### DIFF
--- a/aws_embedded_metrics/environment/default_environment.py
+++ b/aws_embedded_metrics/environment/default_environment.py
@@ -14,6 +14,7 @@
 from aws_embedded_metrics.config import get_config
 from aws_embedded_metrics.environment import Environment
 from aws_embedded_metrics.logger.metrics_context import MetricsContext
+from aws_embedded_metrics.sinks import Sink
 from aws_embedded_metrics.sinks.agent_sink import AgentSink
 from typing import Optional
 
@@ -22,7 +23,7 @@ Config = get_config()
 
 class DefaultEnvironment(Environment):
     def __init__(self) -> None:
-        self.sink: Optional[AgentSink] = None
+        self.sink: Optional[Sink] = None
 
     async def probe(self) -> bool:
         return True
@@ -39,7 +40,7 @@ class DefaultEnvironment(Environment):
     def configure_context(self, context: MetricsContext) -> None:
         pass
 
-    def get_sink(self) -> AgentSink:
+    def get_sink(self) -> Sink:
         if self.sink is None:
             self.sink = AgentSink(self.get_log_group_name(), Config.log_stream_name)
         return self.sink

--- a/aws_embedded_metrics/environment/environment_detector.py
+++ b/aws_embedded_metrics/environment/environment_detector.py
@@ -16,6 +16,7 @@ from aws_embedded_metrics import config
 from aws_embedded_metrics.environment import Environment
 from aws_embedded_metrics.environment.default_environment import DefaultEnvironment
 from aws_embedded_metrics.environment.lambda_environment import LambdaEnvironment
+from aws_embedded_metrics.environment.local_environment import LocalEnvironment
 from aws_embedded_metrics.environment.ec2_environment import EC2Environment
 from typing import Optional
 
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 lambda_environment = LambdaEnvironment()
 ec2_environment = EC2Environment()
 default_environment = DefaultEnvironment()
+local_environment = LocalEnvironment()
 environments = [lambda_environment, ec2_environment]
 Config = config.get_config()
 
@@ -45,6 +47,8 @@ async def resolve_environment() -> Environment:
             EnvironmentCache.environment = ec2_environment
         elif lower_configured_enviroment == "default":
             EnvironmentCache.environment = default_environment
+        elif lower_configured_enviroment == "local":
+            EnvironmentCache.environment = local_environment
         else:
             log.info("Failed to understand environment override: %s", Config.environment)
     if EnvironmentCache.environment is not None:

--- a/aws_embedded_metrics/sinks/stdout_sink.py
+++ b/aws_embedded_metrics/sinks/stdout_sink.py
@@ -17,14 +17,15 @@ from aws_embedded_metrics.serializers import Serializer
 from aws_embedded_metrics.serializers.log_serializer import LogSerializer
 
 
-class LambdaSink(Sink):
+class StdoutSink(Sink):
     def __init__(self, serializer: Serializer = LogSerializer()):
         self.serializer = serializer
 
     def accept(self, context: MetricsContext) -> None:
         for serialized_content in self.serializer.serialize(context):
-            print(serialized_content)
+            if serialized_content:
+                print(serialized_content)
 
     @staticmethod
     def name() -> str:
-        return "LambdaSink"
+        return "StdoutSink"

--- a/tests/environment/test_lambda_environment.py
+++ b/tests/environment/test_lambda_environment.py
@@ -1,6 +1,6 @@
 import os
 from aws_embedded_metrics.environment.lambda_environment import LambdaEnvironment
-from aws_embedded_metrics.sinks.lambda_sink import LambdaSink
+from aws_embedded_metrics.sinks.stdout_sink import StdoutSink
 import pytest
 from faker import Faker
 
@@ -65,4 +65,4 @@ def test_create_sink_creates_LambdaSink():
     result = env.get_sink()
 
     # assert
-    assert isinstance(result, LambdaSink)
+    assert isinstance(result, StdoutSink)

--- a/tests/environment/test_local_environment.py
+++ b/tests/environment/test_local_environment.py
@@ -1,0 +1,108 @@
+from aws_embedded_metrics import config
+from aws_embedded_metrics.environment.local_environment import LocalEnvironment
+from aws_embedded_metrics.sinks.stdout_sink import StdoutSink
+import pytest
+from faker import Faker
+
+Config = config.get_config()
+fake = Faker()
+
+
+@pytest.mark.asyncio
+async def test_probe_always_returns_false():
+    # arrange
+    env = LocalEnvironment()
+
+    # act
+    result = await env.probe()
+
+    # assert
+    assert result is False
+
+
+def test_get_name_returns_unknown_if_not_specified():
+    # arrange
+    env = LocalEnvironment()
+    Config.service_name = None
+
+    # act
+    result = env.get_name()
+
+    # assert
+    assert result == "Unknown"
+
+
+def test_get_type_returns_unknown_if_not_specified():
+    # arrange
+    env = LocalEnvironment()
+    Config.service_type = None
+
+    # act
+    result = env.get_type()
+
+    # assert
+    assert result == "Unknown"
+
+
+def test_get_name_returns_name_if_configured():
+    # arrange
+    expected_name = fake.word()
+    env = LocalEnvironment()
+    Config.service_name = expected_name
+
+    # act
+    result = env.get_name()
+
+    # assert
+    assert result == expected_name
+
+
+def test__get_type__returns_type_if_configured():
+    # arrange
+    expected_type = fake.word()
+    env = LocalEnvironment()
+    Config.service_type = expected_type
+
+    # act
+    result = env.get_type()
+
+    # assert
+    assert result == expected_type
+
+
+def test__get_log_group_name__returns_log_group_if_configured():
+    # arrange
+    expected = fake.word()
+    env = LocalEnvironment()
+    Config.log_group_name = expected
+
+    # act
+    result = env.get_log_group_name()
+
+    # assert
+    assert result == expected
+
+
+def test__get_log_group_name__returns_service_name_metrics_if_not_configured():
+    # arrange
+    expected = fake.word()
+    env = LocalEnvironment()
+    Config.service_name = expected
+    Config.log_group_name = None
+
+    # act
+    result = env.get_log_group_name()
+
+    # assert
+    assert result == f"{expected}-metrics"
+
+
+def test__get_sink__returns_stdout_sink():
+    # arrange
+    env = LocalEnvironment()
+
+    # act
+    result = env.get_sink()
+
+    # assert
+    assert isinstance(result, StdoutSink)


### PR DESCRIPTION
So far the DefaultEnvironment was hard coded to use the agent sink as that
was the recommendation for workloads on-premise.

While a fair recommendation, it isn't accurate for all workloads. This
adds a similer local environment that uses the StdoutSink instead of the agent sink
for such customers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
