### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws-embedded-metrics",
-    version="1.0.6",
+    version="2.0.0",
     author="Amazon Web Services",
     author_email="jarnance@amazon.com",
     description="AWS Embedded Metrics Package",


### PR DESCRIPTION
#63 is a breaking change. Previously, if you were using an incompatible version of Python you would have hit #62 when attempting to import the package. This is a major version bump because we enforce a minimum Python version of 3.6.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
