### PR TITLE
Allow users to disable event serialization if metrics are empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,22 @@ Config = get_config()
 Config.disable_metric_extraction = True
 
 # environment
-AWS_EMF_DISABLE_METRIC_EXTRACTION = true
+AWS_EMF_DISABLE_METRIC_EXTRACTION=true
+```
+
+**ONLY_LOG_EVENTS_WITH_METRICS**: When this property is set to `true`, LogEvents without any metrics
+set will be dropped.
+
+Example:
+
+```py
+# in process
+from aws_embedded_metrics.config import get_config
+Config = get_config()
+Config.only_log_events_with_metrics = True
+
+# environment
+AWS_EMF_ONLY_LOG_EVENTS_WITH_METRICS=true
 ```
 
 ## Examples

--- a/aws_embedded_metrics/config/configuration.py
+++ b/aws_embedded_metrics/config/configuration.py
@@ -27,6 +27,7 @@ class Configuration:
         namespace: str = None,
         disable_metric_extraction: bool = False,
         environment: Optional[str] = None,
+        only_log_events_with_metrics: bool = False,
     ):
         self.debug_logging_enabled = debug_logging_enabled
         self.service_name = service_name
@@ -38,3 +39,4 @@ class Configuration:
         self.namespace = namespace
         self.disable_metric_extraction = disable_metric_extraction
         self.environment = environment
+        self.only_log_events_with_metrics = only_log_events_with_metrics

--- a/aws_embedded_metrics/config/environment_configuration_provider.py
+++ b/aws_embedded_metrics/config/environment_configuration_provider.py
@@ -26,6 +26,7 @@ EC2_METADATA_ENDPOINT = "EC2_METADATA_ENDPOINT"
 NAMESPACE = "NAMESPACE"
 DISABLE_METRIC_EXTRACTION = "DISABLE_METRIC_EXTRACTION"
 ENVIRONMENT_OVERRIDE = "ENVIRONMENT"
+ONLY_LOG_EVENTS_WITH_METRICS = "ONLY_LOG_EVENTS_WITH_METRICS"
 
 
 class EnvironmentConfigurationProvider:
@@ -45,6 +46,7 @@ class EnvironmentConfigurationProvider:
             self.__get_env_var(NAMESPACE),
             self.__get_bool_env_var(DISABLE_METRIC_EXTRACTION),
             self.__get_env_var(ENVIRONMENT_OVERRIDE),
+            self.__get_bool_env_var(ONLY_LOG_EVENTS_WITH_METRICS),
         )
 
     @staticmethod

--- a/aws_embedded_metrics/serializers/log_serializer.py
+++ b/aws_embedded_metrics/serializers/log_serializer.py
@@ -29,6 +29,11 @@ class LogSerializer(Serializer):
         dimension_keys = []
         dimensions_properties: Dict[str, str] = {}
 
+        # allows users to skip emission entirely if no metrics have been
+        # added to the logger
+        if config.only_log_events_with_metrics and not context.metrics:
+            return []
+
         for dimension_set in context.get_dimensions():
             keys = list(dimension_set.keys())
             dimension_keys.append(keys[0:MAX_DIMENSIONS])

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -25,6 +25,7 @@ def test_can_get_config_from_environment(monkeypatch):
     namespace = fake.word()
     disable_metric_extraction = True
     environment_override = fake.word()
+    only_log_events_with_metrics = True
 
     monkeypatch.setenv("AWS_EMF_ENABLE_DEBUG_LOGGING", str(debug_enabled))
     monkeypatch.setenv("AWS_EMF_SERVICE_NAME", service_name)
@@ -36,6 +37,7 @@ def test_can_get_config_from_environment(monkeypatch):
     monkeypatch.setenv("AWS_EMF_NAMESPACE", namespace)
     monkeypatch.setenv("AWS_EMF_DISABLE_METRIC_EXTRACTION", str(disable_metric_extraction))
     monkeypatch.setenv("AWS_EMF_ENVIRONMENT", environment_override)
+    monkeypatch.setenv("AWS_EMF_ONLY_LOG_EVENTS_WITH_METRICS", only_log_events_with_metrics)
 
     # act
     result = get_config()
@@ -51,6 +53,7 @@ def test_can_get_config_from_environment(monkeypatch):
     assert result.namespace == namespace
     assert result.disable_metric_extraction == disable_metric_extraction
     assert result.environment == environment_override
+    assert result.only_log_events_with_metrics == only_log_events_with_metrics
 
 
 def test_can_override_config(monkeypatch):
@@ -65,6 +68,7 @@ def test_can_override_config(monkeypatch):
     monkeypatch.setenv("AWS_EMF_NAMESPACE", fake.word())
     monkeypatch.setenv("AWS_EMF_DISABLE_METRIC_EXTRACTION", str(True))
     monkeypatch.setenv("AWS_EMF_ENVIRONMENT", fake.word())
+    monkeypatch.setenv("AWS_EMF_ONLY_LOG_EVENTS_WITH_METRICS", str(True))
 
     config = get_config()
 
@@ -78,6 +82,7 @@ def test_can_override_config(monkeypatch):
     namespace = fake.word()
     disable_metric_extraction = False
     environment = fake.word()
+    only_log_events_with_metrics = False
 
     # act
     config.debug_logging_enabled = debug_enabled
@@ -90,6 +95,7 @@ def test_can_override_config(monkeypatch):
     config.namespace = namespace
     config.disable_metric_extraction = disable_metric_extraction
     config.environment = environment
+    config.only_log_events_with_metrics = only_log_events_with_metrics
 
     # assert
     assert config.debug_logging_enabled == debug_enabled
@@ -102,3 +108,4 @@ def test_can_override_config(monkeypatch):
     assert config.namespace == namespace
     assert config.disable_metric_extraction == disable_metric_extraction
     assert config.environment == environment
+    assert config.only_log_events_with_metrics == only_log_events_with_metrics

--- a/tests/serializer/test_log_serializer.py
+++ b/tests/serializer/test_log_serializer.py
@@ -280,6 +280,35 @@ def test_serialize_metrics_with_aggregation_disabled():
     assert_json_equality(result_json, expected)
 
 
+def test_serialize_metrics_without_metrics_when_only_log_events_with_metrics_true():
+    """Test log records don't contain metadata when aggregation is disabled."""
+    # arrange
+    config = get_config()
+    config.only_log_events_with_metrics = True
+
+    context = get_context()
+
+    # act
+    result_json = serializer.serialize(context)
+
+    # assert
+    assert len(result_json) == 0
+
+
+def test_serialize_metrics_without_metrics_when_only_log_events_with_metrics_false():
+    """Test log records don't contain metadata when aggregation is disabled."""
+    # arrange
+    config = get_config()
+    config.only_log_events_with_metrics = False
+
+    context = get_context()
+
+    # act
+    result_json = serializer.serialize(context)
+
+    # assert
+    assert len(result_json) == 1
+
 # Test utility method
 
 


### PR DESCRIPTION
*Issue #, if available:* #51

Introduce a new configuration flag `ONLY_LOG_EVENTS_WITH_METRICS` which will allow users to disable serialization unless metrics are present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
