### PR TITLE
Canary using invalid metric value

### DIFF
--- a/tests/canary/agent/canary.py
+++ b/tests/canary/agent/canary.py
@@ -31,7 +31,7 @@ async def app(init, last_run_duration, metrics):
 
 async def main():
     init = True
-    duration = None
+    duration = 0
     # wait for agent to start
     # TODO: this should not be needed if we're using a ring buffer to queue and re-try events
     await asyncio.sleep(10)


### PR DESCRIPTION
*Description of changes:*
Canary is throwing errors due to its use of an invalid metric value.
This value would start as `None` until assigned. It has been changed to initialize to `0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
