### PR TITLE
Disable implicit optional for mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,3 +14,4 @@
   warn_return_any = True
   strict_equality = True
   ignore_missing_imports = True
+  no_implicit_optional = False


### PR DESCRIPTION
*Description of changes:*
mypy's default config for `no_implicit_optional` is `True` which causes mypy to treat arguments with a None default value as having an implicit [Optional]. This was causing our recent builds to fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
