### PR TITLE
Replace User creds with Role creds for CWL agent

### DIFF
--- a/bin/start-agent.sh
+++ b/bin/start-agent.sh
@@ -22,6 +22,7 @@ cd $rootdir/tests/integ/agent
 echo "[AmazonCloudWatchAgent]
 aws_access_key_id = $AWS_ACCESS_KEY_ID
 aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+aws_session_token = $AWS_SESSION_TOKEN
 " > ./.aws/credentials
 
 echo "[profile AmazonCloudWatchAgent]

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ passenv =
     AWS_REGION
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN
 
 [testenv:flake8]
 basepython = python3.7


### PR DESCRIPTION
*Description of changes:*

- Implement AWS STS assume-role to obtain short-term credentials
- Store credentials in environment variables for AWS CLI usage
- Update CloudWatch Agent configuration to use temporary credentials
- Improve security by eliminating long-term IAM user credentials

The change uses the CodeBuild execution role to generate temporary 
credentials with a 1-hour duration, enhancing security through 
credential rotation.
