### PR TITLE
changed cw-agent dockerhub image to use ecr

### DIFF
--- a/tests/canary/agent/container-definitions.json
+++ b/tests/canary/agent/container-definitions.json
@@ -30,7 +30,7 @@
   },
   {
     "name": "cloudwatch-agent-python",
-    "image": "amazon/cloudwatch-agent:latest",
+    "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed cloudwatch agent dockerhub image to use ECR version instead, this is to be consistent with this PR: https://github.com/awslabs/aws-embedded-metrics-java/pull/164

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
