### PR TITLE
Updated README to use the right case for the `set_property` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Adds a new set of dimensions that will be associated to all metric values.
 
 **WARNING**: Every distinct value will result in a new CloudWatch Metric.
 If the cardinality of a particular value is expected to be high, you should consider
-using `setProperty` instead.
+using `set_property` instead.
 
 Requirements:
 
@@ -128,7 +128,7 @@ Explicitly override all dimensions. By default, this will disable the default di
 
 **WARNING**: Every distinct value will result in a new CloudWatch Metric.
 If the cardinality of a particular value is expected to be high, you should consider
-using `setProperty` instead.
+using `set_property` instead.
 
 Requirements:
 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

The examples setting dimensions mentioned to use `setProperty` when dealing with high cardinality metrics. This should instead refer to `set_property`, which is the Python method and the one referred to throughout the rest of the README. The current casing might lead to confusion and make users believe there is a separate `setProperty` function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
