### PR TITLE
Publish new major version 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="aws-embedded-metrics",
-    version="3.3.1",
+    version="4.0.0",
     author="Amazon Web Services",
     author_email="jarnance@amazon.com",
     description="AWS Embedded Metrics Package",


### PR DESCRIPTION
Publish a new major version, as typing change that was introduced with version `3.3.1` through this PR: https://github.com/awslabs/aws-embedded-metrics-python/pull/70  broke the build for several consumers. Publishing a new major version ensures that consumers that use `3.x` and `3.3.x` will still be able use this library, and consumers that want to use proper typing can just upgrade to the latest major version

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
