### PR TITLE
Fix unhandled exception in error logging by providing the same number of vars and args

### DIFF
--- a/aws_embedded_metrics/environment/environment_detector.py
+++ b/aws_embedded_metrics/environment/environment_detector.py
@@ -61,7 +61,7 @@ async def resolve_environment() -> Environment:
             is_environment = await env_under_test.probe()
         except Exception as e:
             log.error(
-                "Failed to detect enironment: %s", env_under_test.__class__.__name__, e
+                "Failed to detect environment: %s Exception: %s", env_under_test.__class__.__name__, e
             )
             pass
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This particular log line, if it can't detect the environment will throw an unhandled exception `TypeError: not all arguments converted during string formatting`

This is because I think it's just not using the logging library correctly. Example usage: https://docs.python.org/3/howto/logging-cookbook.html#customized-exception-formatting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
