### PR TITLE
fix: migrate canary base image from python:3.7 to python:3.12-slim

### DIFF
--- a/tests/canary/agent/Dockerfile
+++ b/tests/canary/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM public.ecr.aws/docker/library/python:3.12-slim
 
 RUN mkdir /app
 WORKDIR /app
@@ -6,6 +6,6 @@ WORKDIR /app
 ADD canary.py .
 ADD start.sh .
 RUN python3 -m venv ./venv
-ADD venv/lib/python3.7/site-packages /app/venv/lib/python3.7/site-packages
+ADD venv/lib/python3.12/site-packages /app/venv/lib/python3.12/site-packages
 
 CMD [ "./start.sh" ]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* python:3.7 reached end-of-life in June 2023. Migrate to python:3.12-slim to ensure regular security patches.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
