### PR TITLE
fix: update tox configuration to use python3.12

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,mypy,py37
+envlist = flake8,mypy,py312
 
 [testenv]
 deps = 
@@ -26,13 +26,13 @@ passenv =
     AWS_SESSION_TOKEN
 
 [testenv:flake8]
-basepython = python3.7
+basepython = python3.12
 deps = flake8
 commands =
     flake8 aws_embedded_metrics tests
 
 [testenv:mypy]
-basepython=python3.7
+basepython=python3.12
 deps = mypy
 commands =
     mypy aws_embedded_metrics


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* python3.7 reached end-of-life in June 2023. Update tox envlist, flake8, and mypy environments to use python3.12.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
