### PR TITLE
fix: allow @metric_scope sync wrappers to work inside asyncio event loops

### DIFF
--- a/aws_embedded_metrics/environment/environment_detector.py
+++ b/aws_embedded_metrics/environment/environment_detector.py
@@ -14,13 +14,15 @@
 import logging
 import asyncio
 import concurrent.futures
+from collections.abc import Callable, Coroutine
+
 from aws_embedded_metrics import config
 from aws_embedded_metrics.environment import Environment
 from aws_embedded_metrics.environment.default_environment import DefaultEnvironment
 from aws_embedded_metrics.environment.lambda_environment import LambdaEnvironment
 from aws_embedded_metrics.environment.local_environment import LocalEnvironment
 from aws_embedded_metrics.environment.ec2_environment import EC2Environment
-from typing import Optional
+from typing import Optional, Any
 
 log = logging.getLogger(__name__)
 
@@ -34,18 +36,6 @@ Config = config.get_config()
 
 class EnvironmentCache:
     environment: Optional[Environment] = None
-
-
-def resolve_environment_sync() -> Environment:
-    if EnvironmentCache.environment is not None:
-        return EnvironmentCache.environment
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(resolve_environment())
-    else:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(asyncio.run, resolve_environment()).result()
 
 
 async def resolve_environment() -> Environment:
@@ -87,3 +77,17 @@ async def resolve_environment() -> Environment:
     log.info("No environment was detected. Using default.")
     EnvironmentCache.environment = default_environment
     return EnvironmentCache.environment
+
+
+def resolve_environment_sync(
+        resolve_env_fn: Callable[[], Coroutine[Any, Any, Environment]] = resolve_environment
+) -> Environment:
+    if EnvironmentCache.environment is not None:
+        return EnvironmentCache.environment
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(resolve_env_fn())
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, resolve_env_fn()).result()

--- a/aws_embedded_metrics/environment/environment_detector.py
+++ b/aws_embedded_metrics/environment/environment_detector.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 import logging
+import asyncio
+import concurrent.futures
 from aws_embedded_metrics import config
 from aws_embedded_metrics.environment import Environment
 from aws_embedded_metrics.environment.default_environment import DefaultEnvironment
@@ -32,6 +34,18 @@ Config = config.get_config()
 
 class EnvironmentCache:
     environment: Optional[Environment] = None
+
+
+def resolve_environment_sync() -> Environment:
+    if EnvironmentCache.environment is not None:
+        return EnvironmentCache.environment
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(resolve_environment())
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, resolve_environment()).result()
 
 
 async def resolve_environment() -> Environment:

--- a/aws_embedded_metrics/logger/metrics_logger.py
+++ b/aws_embedded_metrics/logger/metrics_logger.py
@@ -16,6 +16,7 @@ from aws_embedded_metrics.environment import Environment
 from aws_embedded_metrics.environment.environment_detector import resolve_environment_sync
 from aws_embedded_metrics.logger.metrics_context import MetricsContext
 from aws_embedded_metrics.validator import validate_namespace
+from aws_embedded_metrics.utils import _await
 from aws_embedded_metrics.config import get_config
 from aws_embedded_metrics.storage_resolution import StorageResolution
 from typing import Any, Awaitable, Callable, Dict, Tuple
@@ -36,7 +37,7 @@ class MetricsLogger:
         self.flush_preserve_dimensions: bool = False
 
     def flush_sync(self) -> None:
-        environment = resolve_environment_sync()
+        environment = resolve_environment_sync(lambda: _await(self.resolve_environment()))
         self.__flush_with_environment(environment)
 
     async def flush(self) -> None:

--- a/aws_embedded_metrics/logger/metrics_logger.py
+++ b/aws_embedded_metrics/logger/metrics_logger.py
@@ -13,6 +13,7 @@
 
 from datetime import datetime
 from aws_embedded_metrics.environment import Environment
+from aws_embedded_metrics.environment.environment_detector import resolve_environment_sync
 from aws_embedded_metrics.logger.metrics_context import MetricsContext
 from aws_embedded_metrics.validator import validate_namespace
 from aws_embedded_metrics.config import get_config
@@ -34,17 +35,21 @@ class MetricsLogger:
         self.context: MetricsContext = context or MetricsContext.empty()
         self.flush_preserve_dimensions: bool = False
 
+    def flush_sync(self) -> None:
+        environment = resolve_environment_sync()
+        self.__flush_with_environment(environment)
+
     async def flush(self) -> None:
         # resolve the environment and get the sink
         # MOST of the time this will run synchonrously
         # This only runs asynchronously if executing for the
         # first time in a non-lambda environment
         environment = await self.resolve_environment()
+        self.__flush_with_environment(environment)
 
+    def __flush_with_environment(self, environment: Environment) -> None:
         self.__configure_context_for_environment(environment)
         sink = environment.get_sink()
-
-        # accept and reset the context
         sink.accept(self.context)
         self.context = self.context.create_copy_with_context(self.flush_preserve_dimensions)
 

--- a/aws_embedded_metrics/metric_scope/__init__.py
+++ b/aws_embedded_metrics/metric_scope/__init__.py
@@ -49,10 +49,10 @@ def _build_decorator(fn: F, flush_on_yield: bool) -> F:
             try:
                 for result in fn(*args, **kwargs):
                     if flush_on_yield:
-                        asyncio.run(logger.flush())
+                        logger.flush_sync()
                     yield result
             finally:
-                asyncio.run(logger.flush())
+                logger.flush_sync()
 
         return cast(F, gen_wrapper)
 
@@ -80,7 +80,7 @@ def _build_decorator(fn: F, flush_on_yield: bool) -> F:
             try:
                 return fn(*args, **kwargs)
             finally:
-                asyncio.run(logger.flush())
+                logger.flush_sync()
 
         return cast(F, wrapper)
 

--- a/aws_embedded_metrics/utils.py
+++ b/aws_embedded_metrics/utils.py
@@ -12,7 +12,14 @@
 # limitations under the License.
 
 import time
+from collections.abc import Awaitable
 from datetime import datetime
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
 def now() -> int: return int(round(time.time() * 1000))
 
 
@@ -21,3 +28,7 @@ def convert_to_milliseconds(dt: datetime) -> int:
         return 0
 
     return int(round(dt.timestamp() * 1000))
+
+
+async def _await(awaitable: Awaitable[T]) -> T:
+    return await awaitable

--- a/tests/environment/test_environment_detector.py
+++ b/tests/environment/test_environment_detector.py
@@ -1,4 +1,5 @@
 from faker import Faker
+import asyncio
 import os
 import pytest
 from importlib import reload
@@ -87,3 +88,20 @@ async def test_resolve_environment_returns_override_lambda(before, monkeypatch):
 
     # assert
     assert isinstance(result, LambdaEnvironment)
+
+
+@pytest.mark.asyncio
+async def test_resolve_environment_sync_works_inside_running_event_loop(before, monkeypatch):
+    # arrange
+    monkeypatch.setenv("AWS_EMF_ENVIRONMENT", "default")
+    reload(config)
+    reload(environment_detector)
+    # verify we are inside a running loop
+    loop = asyncio.get_running_loop()
+    assert loop.is_running()
+
+    # act
+    result = environment_detector.resolve_environment_sync()
+
+    # assert
+    assert isinstance(result, DefaultEnvironment)

--- a/tests/environment/test_environment_detector.py
+++ b/tests/environment/test_environment_detector.py
@@ -105,3 +105,35 @@ async def test_resolve_environment_sync_works_inside_running_event_loop(before, 
 
     # assert
     assert isinstance(result, DefaultEnvironment)
+
+
+def test_resolve_environment_sync_with_async_resolve_env_fn(before):
+    # arrange
+    expected = DefaultEnvironment()
+
+    async def async_resolve():
+        return expected
+
+    # act
+    result = environment_detector.resolve_environment_sync(async_resolve)
+
+    # assert
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_resolve_environment_sync_with_async_resolve_env_fn_inside_running_loop(before):
+    # arrange
+    expected = DefaultEnvironment()
+
+    async def async_resolve():
+        return expected
+
+    loop = asyncio.get_running_loop()
+    assert loop.is_running()
+
+    # act
+    result = environment_detector.resolve_environment_sync(async_resolve)
+
+    # assert
+    assert result is expected

--- a/tests/logger/test_metrics_logger.py
+++ b/tests/logger/test_metrics_logger.py
@@ -509,6 +509,39 @@ async def test_can_set_timestamp(mocker):
     context = get_flushed_context(sink)
     assert context.meta[constants.TIMESTAMP] == utils.convert_to_milliseconds(expected_value)
 
+
+def test_flush_sync_sends_context_to_sink(mocker):
+    # arrange
+    from aws_embedded_metrics.environment import environment_detector
+    env = mocker.create_autospec(spec=Environment)
+    sink = mocker.create_autospec(spec=Sink)
+    env.get_sink.return_value = sink
+    env.get_log_group_name.return_value = fake.word()
+    env.get_name.return_value = fake.word()
+    env.get_type.return_value = fake.word()
+
+    environment_detector.EnvironmentCache.environment = env
+
+    reload(config)
+    reload(metrics_logger)
+
+    logger = metrics_logger.MetricsLogger(lambda: None)
+
+    expected_key = fake.word()
+    expected_value = fake.word()
+    logger.set_property(expected_key, expected_value)
+
+    # act
+    logger.flush_sync()
+
+    # assert
+    context = get_flushed_context(sink)
+    assert context.properties[expected_key] == expected_value
+
+    # cleanup
+    environment_detector.EnvironmentCache.environment = None
+
+
 # Test helper methods
 
 

--- a/tests/logger/test_metrics_logger.py
+++ b/tests/logger/test_metrics_logger.py
@@ -8,7 +8,6 @@ from aws_embedded_metrics.storage_resolution import StorageResolution
 import aws_embedded_metrics.constants as constants
 import pytest
 from faker import Faker
-from asyncio import Future
 from importlib import reload
 import os
 import sys
@@ -512,23 +511,10 @@ async def test_can_set_timestamp(mocker):
 
 def test_flush_sync_sends_context_to_sink(mocker):
     # arrange
-    from aws_embedded_metrics.environment import environment_detector
-    env = mocker.create_autospec(spec=Environment)
-    sink = mocker.create_autospec(spec=Sink)
-    env.get_sink.return_value = sink
-    env.get_log_group_name.return_value = fake.word()
-    env.get_name.return_value = fake.word()
-    env.get_type.return_value = fake.word()
-
-    environment_detector.EnvironmentCache.environment = env
-
-    reload(config)
-    reload(metrics_logger)
-
-    logger = metrics_logger.MetricsLogger(lambda: None)
-
     expected_key = fake.word()
     expected_value = fake.word()
+
+    logger, sink, env = get_logger_and_sink(mocker)
     logger.set_property(expected_key, expected_value)
 
     # act
@@ -537,9 +523,6 @@ def test_flush_sync_sends_context_to_sink(mocker):
     # assert
     context = get_flushed_context(sink)
     assert context.properties[expected_key] == expected_value
-
-    # cleanup
-    environment_detector.EnvironmentCache.environment = None
 
 
 # Test helper methods
@@ -555,10 +538,8 @@ def before():
 def get_logger_and_sink(mocker):
     env = mocker.create_autospec(spec=Environment)
 
-    def env_provider():
-        result_future = Future()
-        result_future.set_result(env)
-        return result_future
+    async def env_provider():
+        return env
 
     sink = mocker.create_autospec(spec=Sink)
     env.get_sink.return_value = sink

--- a/tests/metric_scope/test_metric_scope.py
+++ b/tests/metric_scope/test_metric_scope.py
@@ -16,7 +16,12 @@ def mock_logger(mocker):
         print("flush called")
         InvocationTracker.record()
 
+    def flush_sync(self):
+        print("flush_sync called")
+        InvocationTracker.record()
+
     MetricsLogger.flush = flush
+    MetricsLogger.flush_sync = flush_sync
 
 
 @pytest.mark.asyncio
@@ -319,6 +324,43 @@ def test_sync_generator_respects_default_config_flush_on_yield(mock_logger, flus
         assert InvocationTracker.invocations == expected_num_of_flushes
     finally:
         get_config().default_flush_on_yield = original_flush_on_yield
+
+
+@pytest.mark.asyncio
+async def test_sync_scope_works_inside_running_event_loop(mock_logger):
+    # arrange
+    expected_result = True
+
+    @metric_scope
+    def my_handler():
+        return expected_result
+
+    # act
+    actual_result = my_handler()
+
+    # assert
+    assert expected_result == actual_result
+    assert InvocationTracker.invocations == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_generator_works_inside_running_event_loop(mock_logger):
+    # arrange
+    expected_results = [1, 2, 3]
+
+    @metric_scope
+    def my_handler():
+        yield from expected_results
+
+    # act
+    actual_results = []
+    for result in my_handler():
+        actual_results.append(result)
+
+    # assert
+    assert actual_results == expected_results
+    # TODO in v4: change to 1 — default_flush_on_yield becomes False, flushing only once at completion
+    assert InvocationTracker.invocations == 4  # 3 yields + 1 final flush
 
 
 # Test helpers


### PR DESCRIPTION
Fixes #131 

## Summary
Add synchronous flush and environment resolution paths that work regardless of whether an event loop is running:

• `resolve_environment_sync()` in `environment_detector.py` — checks for a cached environment first, then detects whether an event loop is running. If no loop is running, uses `asyncio.run()`. If a loop is running, offloads the async resolution to a `ThreadPoolExecutor` to avoid the `RuntimeError`.
• `flush_sync()` in `MetricsLogger` — calls `resolve_environment_sync()` and flushes the context synchronously. Shares the same `__flush_with_environment()` helper as the async `flush()`.
• Sync wrappers in `metric_scope/__init__.py` now call `logger.flush_sync()` instead of `asyncio.run(logger.flush())`.

The async `flush()` path is unchanged — this is purely additive for the sync codepath.

## Testing
• 4 new tests covering `resolve_environment_sync`, `flush_sync`, and both sync function/generator wrappers inside a running event loop

## Dependencies
⚠️ This PR is stacked on #136, as there would be merge conflict anyway. This PR contains one extra commit on top of it.